### PR TITLE
Secp256k1

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "secp256k1"]
+	path = secp256k1
+	url = https://github.com/bitcoin-core/secp256k1.git

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 default:
 	mkdir -p bin
-	gcc src/vanity.c -Ofast -lcrypto -lkeccak -lpthread -o bin/vanity
+	gcc src/vanity.c -Ofast -Wno-unused-result -lcrypto -lkeccak -lpthread -lsecp256k1 -o bin/vanity
 install:
 	cp bin/vanity /usr/local/bin/vanity

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 default:
 	mkdir -p bin
-	gcc src/vanity.c -Ofast -Wno-unused-result -lcrypto -lkeccak -lpthread -lsecp256k1 -o bin/vanity
+	gcc src/vanity.c -Ofast -Wno-unused-result -Isecp256k1/include -Isecp256k1 -Lsecp256k1/src -Lsecp256k1 -lgmp -lsecp256k1 -lkeccak -lpthread  -o bin/vanity
 install:
 	cp bin/vanity /usr/local/bin/vanity

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,18 @@
-default:
+CC=gcc
+IDIRS=-Isecp256k1/include -Isecp256k1
+LDIRS=-Lsecp256k1/src -Lsecp256k1
+LIBS=-lgmp -lsecp256k1 -lkeccak -lpthread
+CFLAGS=$(IDIRS) $(LDIRS) $(LIBS)
+
+vanity: src/vanity.c secp256k1/src/libsecp256k1-config.h secp256k1/src/ecmult_static_context.h
 	mkdir -p bin
-	gcc src/vanity.c -Ofast -Wno-unused-result -Isecp256k1/include -Isecp256k1 -Lsecp256k1/src -Lsecp256k1 -lgmp -lsecp256k1 -lkeccak -lpthread  -o bin/vanity
+	$(CC) src/vanity.c -Ofast -Wno-unused-result -funsafe-loop-optimizations $(CFLAGS) -o bin/vanity
 install:
 	cp bin/vanity /usr/local/bin/vanity
+
+secp256k1/src/libsecp256k1-config.h:
+	(cd secp256k1;./autogen.sh;./configure --enable-endomorphism)
+
+
+secp256k1/src/ecmult_static_context.h:
+	$(MAKE) -C secp256k1 src/ecmult_static_context.h

--- a/src/vanity.c
+++ b/src/vanity.c
@@ -5,8 +5,12 @@
 #include <pthread.h>
 #include <unistd.h>
 #include <time.h>
-#include <secp256k1.h>
 #include <sys/random.h>
+
+#define STEP 3072
+#include "src/libsecp256k1-config.h"
+#include "src/secp256k1.c"
+
 
 #define ascii_to_byte(chr) (chr % 32 + 9) % 25
 
@@ -66,7 +70,7 @@ void *generate_address(void * param){
   unsigned char public_key[65];
   size_t publen = 65;
 
-  secp256k1_context *ctx = secp256k1_context_create(SECP256K1_CONTEXT_VERIFY | SECP256K1_FLAGS_BIT_CONTEXT_SIGN);
+  secp256k1_context *ctx = secp256k1_context_create(SECP256K1_CONTEXT_VERIFY | SECP256K1_CONTEXT_SIGN);
   secp256k1_pubkey pub;
   unsigned char prv[32];
   getrandom(prv, 32, 0);


### PR DESCRIPTION
* Rewrite EC operations to use BTC-Core's experimental secp256k1 library
* Use efficient graph endomorphisms to triple addresses/second
* Better automate build system